### PR TITLE
onMidpoint fix when working with features that are not bezierGroups

### DIFF
--- a/src/lib/modes/directModeBezierOverride.js
+++ b/src/lib/modes/directModeBezierOverride.js
@@ -140,6 +140,13 @@ DirectModeBezierOverride.onMidpoint = function(state, e) {
     state.selectedCoordPaths = [newCoordPath];
     const selectedCoordinates = this.pathsToCoordinates(state.featureId, state.selectedCoordPaths);
     this.setSelectedCoordinates(selectedCoordinates);
+  } else {
+    // IF NOT A BEZIER GROUP : classic handling
+    this.startDragging(state, e);
+    const about = e.featureTarget.properties;
+    state.feature.addCoordinate(about.coord_path, about.lng, about.lat);
+    this.fireUpdate();
+    state.selectedCoordPaths = [about.coord_path];
   }
 };
 


### PR DESCRIPTION
Hi! Sorry for the out-of-the-blue PR

I've stumbled with your great tool for bezier curves drawing while working on a project that integrates multiple mapbox plugins and modes.
Using them, we end up having quite a few geojson features alive at the same time, from different sources. Some of them are bezier curves, and others not.
So in order to keep the functionality offered by the `onMidpoint` function present on mapbox-draw's `direct_select` mode, i've added this else clause to your if statement. Ideally i would've tried to delegate on the original function, but didn't want to mess up with the way it's currently architectured or rebinding JS functions 😂
So, inspired by the way you did classic handling on the `dragVertex` override, i just added the original code from [the original onMidpoint](https://github.com/mapbox/mapbox-gl-draw/blob/0efdb4d14a0ecae37cfe467334aaa5b2e501f702/src/modes/direct_select.js#L57) to the else statement and it worked straight away, at least for our use case.

Feel free to merge or dismiss this PR, just hoping it helps a little to anyone with a similar use case.

Cheers!
